### PR TITLE
Treat CAVE_AIR just like normal AIR blocks

### DIFF
--- a/src/main/java/org/mcteam/ancientgates/commands/base/CommandAddFrom.java
+++ b/src/main/java/org/mcteam/ancientgates/commands/base/CommandAddFrom.java
@@ -2,6 +2,7 @@ package org.mcteam.ancientgates.commands.base;
 
 import java.util.List;
 
+import com.cryptomorin.xseries.XBlock;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -35,9 +36,9 @@ public class CommandAddFrom extends BaseCommand {
 		final Block playerBlock = player.getLocation().getBlock();
 		final Block upBlock = playerBlock.getRelative(BlockFace.UP);
 
-		if (playerBlock.getType() == Material.AIR) {
+		if (XBlock.isAir(playerBlock.getType())) {
 			gate.addFrom(playerBlock.getLocation());
-		} else if (upBlock.getType() == Material.AIR) {
+		} else if (XBlock.isAir(upBlock.getType())) {
 			gate.addFrom(upBlock.getLocation());
 		} else {
 			sendMessage("There is not enough room for a gate to open here");

--- a/src/main/java/org/mcteam/ancientgates/commands/base/CommandOpen.java
+++ b/src/main/java/org/mcteam/ancientgates/commands/base/CommandOpen.java
@@ -2,6 +2,7 @@ package org.mcteam.ancientgates.commands.base;
 
 import java.util.List;
 
+import com.cryptomorin.xseries.XBlock;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.command.CommandSender;
@@ -39,7 +40,7 @@ public class CommandOpen extends BaseCommand {
 		}
 
 		for (final Location from : gate.getFroms()) {
-			if (from.getBlock().getType() != Material.AIR && !BlockUtil.isStandableGateMaterial(from.getBlock().getType())) {
+			if (!XBlock.isAir(from.getBlock().getType()) && !BlockUtil.isStandableGateMaterial(from.getBlock().getType())) {
 				sendMessage("The gate could not open. The from location is not air.");
 				return;
 			}

--- a/src/main/java/org/mcteam/ancientgates/commands/base/CommandSetFrom.java
+++ b/src/main/java/org/mcteam/ancientgates/commands/base/CommandSetFrom.java
@@ -2,6 +2,7 @@ package org.mcteam.ancientgates.commands.base;
 
 import java.util.List;
 
+import com.cryptomorin.xseries.XBlock;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
@@ -42,10 +43,10 @@ public class CommandSetFrom extends BaseCommand {
 		final Block playerBlock = player.getLocation().getBlock();
 		final Block upBlock = playerBlock.getRelative(BlockFace.UP);
 
-		if (playerBlock.getType() == Material.AIR) {
+		if (XBlock.isAir(playerBlock.getType())) {
 			gate.addFrom(null); // Wipe previous from
 			gate.addFrom(playerBlock.getLocation());
-		} else if (upBlock.getType() == Material.AIR) {
+		} else if (XBlock.isAir(upBlock.getType())) {
 			gate.addFrom(null); // Wipe previous from
 			gate.addFrom(upBlock.getLocation());
 		} else {

--- a/src/main/java/org/mcteam/ancientgates/util/BlockUtil.java
+++ b/src/main/java/org/mcteam/ancientgates/util/BlockUtil.java
@@ -28,7 +28,7 @@ public class BlockUtil {
 		standableMaterials = new EnumMap<>(Material.class);
 		try {
 			Arrays.asList(GateMaterial.values()).stream().forEach(x -> standableMaterials.put(x.getMaterial(), true));
-			standableMaterials.put(Material.AIR, true); // 0 Air
+			standableMaterials.put(XMaterial.AIR.parseMaterial(), true); // 0 Air
 			standableMaterials.put(XMaterial.OAK_SAPLING.parseMaterial(), true); // 6 Saplings
 			standableMaterials.put(Material.WATER, true); // 8 Water - leave even though its in gate materials for stationary
 			standableMaterials.put(Material.LAVA, true); // 10 Lava - leave even though its in gate materials for stationary

--- a/src/main/java/org/mcteam/ancientgates/util/BlockUtil.java
+++ b/src/main/java/org/mcteam/ancientgates/util/BlockUtil.java
@@ -28,7 +28,8 @@ public class BlockUtil {
 		standableMaterials = new EnumMap<>(Material.class);
 		try {
 			Arrays.asList(GateMaterial.values()).stream().forEach(x -> standableMaterials.put(x.getMaterial(), true));
-			standableMaterials.put(XMaterial.AIR.parseMaterial(), true); // 0 Air
+			standableMaterials.put(Material.AIR, true); // 0 Air
+			standableMaterials.put(XMaterial.CAVE_AIR.parseMaterial(), true); // Cave Air
 			standableMaterials.put(XMaterial.OAK_SAPLING.parseMaterial(), true); // 6 Saplings
 			standableMaterials.put(Material.WATER, true); // 8 Water - leave even though its in gate materials for stationary
 			standableMaterials.put(Material.LAVA, true); // 10 Lava - leave even though its in gate materials for stationary


### PR DESCRIPTION
Recently, Minecraft began using CAVE_AIR for air blocks inside of caves, however AncientGates presently does not recognize this as air and refuses to construct portals inside of caves.

This PR resolves this issue. It has been successfully tested on a server running Minecraft 1.20 with no issues.