### PR TITLE
Bump XSeries to 13.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,10 @@
 			<id>CodeMC</id>
 			<url>https://repo.codemc.org/repository/maven-public/</url>
 		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
@@ -172,7 +176,7 @@
 		<dependency>
 			<groupId>com.github.cryptomorin</groupId>
 			<artifactId>XSeries</artifactId>
-			<version>10.0.0</version>
+			<version>13.8.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/mcteam/ancientgates/Gates.java
+++ b/src/main/java/org/mcteam/ancientgates/Gates.java
@@ -127,7 +127,7 @@ public class Gates {
 				coord.getBlock().setBiome(Biome.FOREST);
 			}
 			if (orientation == FloodOrientation.VERTICAL1 && material == GateMaterial.PORTAL) {
-				if (XMaterial.supports(13)) {
+				if (XMaterial.supports(13, 0)) {
 					final BlockData orientable = coord.getBlock().getBlockData();
 					((Orientable) orientable).setAxis(Axis.Z);
 					coord.getBlock().setBlockData(orientable);

--- a/src/main/java/org/mcteam/ancientgates/util/types/GateMaterial.java
+++ b/src/main/java/org/mcteam/ancientgates/util/types/GateMaterial.java
@@ -20,7 +20,7 @@ public enum GateMaterial {
 	ENDPORTAL("ender portal blocks", XMaterial.END_PORTAL.parseMaterial()),
 
 	// LAVA
-	LAVA("stationary lava blocks", XMaterial.supports(13) ? Material.LAVA : Material.getMaterial("STATIONARY_LAVA")),
+	LAVA("stationary lava blocks", XMaterial.supports(13, 0) ? Material.LAVA : Material.getMaterial("STATIONARY_LAVA")),
 
 	// NETHER
 	PORTAL("nether blocks", XMaterial.NETHER_PORTAL.parseMaterial()),
@@ -29,7 +29,7 @@ public enum GateMaterial {
 	SUGARCANE("sugarcane blocks", XMaterial.SUGAR_CANE.parseMaterial()),
 
 	// WATER
-	WATER("stationary water blocks", XMaterial.supports(13) ? Material.WATER : Material.getMaterial("STATIONARY_WATER")),
+	WATER("stationary water blocks", XMaterial.supports(13, 0) ? Material.WATER : Material.getMaterial("STATIONARY_WATER")),
 
 	// WEB
 	WEB("spiders web blocks", XMaterial.COBWEB.parseMaterial());


### PR DESCRIPTION
AncientGates currently shades XSeries 10.0.0. On newer Paper/Minecraft 26.x builds this old XSeries parser fails during XMaterial initialization with messages like:\n\n`Failed to parse server version from: 26.2-25-13f9986 (MC: 26.2)`\n\nXSeries 13.8.0 includes the newer version parsing path that accepts current Bukkit/Paper version formats, so this bumps the dependency from 10.0.0 to 13.8.0.\n\nValidation: `git diff --check` passes. Runtime motivation comes from Paper 26.2 startup failure in AncientGates 2.7.1.