### PR TITLE
Update XSeries for newer Paper versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,6 +125,10 @@
 			<id>CodeMC</id>
 			<url>https://repo.codemc.org/repository/maven-public/</url>
 		</repository>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
 	</repositories>
 
 	<dependencies>
@@ -172,7 +176,7 @@
 		<dependency>
 			<groupId>com.github.cryptomorin</groupId>
 			<artifactId>XSeries</artifactId>
-			<version>10.0.0</version>
+			<version>13.8.0</version>
 		</dependency>
 
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -125,10 +125,6 @@
 			<id>CodeMC</id>
 			<url>https://repo.codemc.org/repository/maven-public/</url>
 		</repository>
-		<repository>
-			<id>jitpack.io</id>
-			<url>https://jitpack.io</url>
-		</repository>
 	</repositories>
 
 	<dependencies>
@@ -176,7 +172,7 @@
 		<dependency>
 			<groupId>com.github.cryptomorin</groupId>
 			<artifactId>XSeries</artifactId>
-			<version>13.8.0</version>
+			<version>13.7.0</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/mcteam/ancientgates/Gates.java
+++ b/src/main/java/org/mcteam/ancientgates/Gates.java
@@ -14,7 +14,7 @@ import org.mcteam.ancientgates.util.types.FloodOrientation;
 import org.mcteam.ancientgates.util.types.GateMaterial;
 import org.mcteam.ancientgates.util.types.WorldCoord;
 
-import com.cryptomorin.xseries.XMaterial;
+import com.cryptomorin.xseries.reflection.XReflection;
 
 public class Gates {
 
@@ -127,7 +127,7 @@ public class Gates {
 				coord.getBlock().setBiome(Biome.FOREST);
 			}
 			if (orientation == FloodOrientation.VERTICAL1 && material == GateMaterial.PORTAL) {
-				if (XMaterial.supports(13, 0)) {
+				if (XReflection.supports(13)) {
 					final BlockData orientable = coord.getBlock().getBlockData();
 					((Orientable) orientable).setAxis(Axis.Z);
 					coord.getBlock().setBlockData(orientable);

--- a/src/main/java/org/mcteam/ancientgates/Gates.java
+++ b/src/main/java/org/mcteam/ancientgates/Gates.java
@@ -127,7 +127,7 @@ public class Gates {
 				coord.getBlock().setBiome(Biome.FOREST);
 			}
 			if (orientation == FloodOrientation.VERTICAL1 && material == GateMaterial.PORTAL) {
-				if (XMaterial.supports(13)) {
+				if (XMaterial.supports(13, 0)) {
 					final BlockData orientable = coord.getBlock().getBlockData();
 					((Orientable) orientable).setAxis(Axis.Z);
 					coord.getBlock().setBlockData(orientable);

--- a/src/main/java/org/mcteam/ancientgates/util/types/GateMaterial.java
+++ b/src/main/java/org/mcteam/ancientgates/util/types/GateMaterial.java
@@ -20,7 +20,7 @@ public enum GateMaterial {
 	ENDPORTAL("ender portal blocks", XMaterial.END_PORTAL.parseMaterial()),
 
 	// LAVA
-	LAVA("stationary lava blocks", XMaterial.supports(13) ? Material.LAVA : Material.getMaterial("STATIONARY_LAVA")),
+	LAVA("stationary lava blocks", XMaterial.supports(13, 0) ? Material.LAVA : Material.getMaterial("STATIONARY_LAVA")),
 
 	// NETHER
 	PORTAL("nether blocks", XMaterial.NETHER_PORTAL.parseMaterial()),
@@ -29,7 +29,7 @@ public enum GateMaterial {
 	SUGARCANE("sugarcane blocks", XMaterial.SUGAR_CANE.parseMaterial()),
 
 	// WATER
-	WATER("stationary water blocks", XMaterial.supports(13) ? Material.WATER : Material.getMaterial("STATIONARY_WATER")),
+	WATER("stationary water blocks", XMaterial.supports(13, 0) ? Material.WATER : Material.getMaterial("STATIONARY_WATER")),
 
 	// WEB
 	WEB("spiders web blocks", XMaterial.COBWEB.parseMaterial());

--- a/src/main/java/org/mcteam/ancientgates/util/types/GateMaterial.java
+++ b/src/main/java/org/mcteam/ancientgates/util/types/GateMaterial.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import org.bukkit.Material;
 
 import com.cryptomorin.xseries.XMaterial;
+import com.cryptomorin.xseries.reflection.XReflection;
 
 public enum GateMaterial {
 	// AIR
@@ -20,7 +21,7 @@ public enum GateMaterial {
 	ENDPORTAL("ender portal blocks", XMaterial.END_PORTAL.parseMaterial()),
 
 	// LAVA
-	LAVA("stationary lava blocks", XMaterial.supports(13, 0) ? Material.LAVA : Material.getMaterial("STATIONARY_LAVA")),
+	LAVA("stationary lava blocks", XReflection.supports(13) ? Material.LAVA : Material.getMaterial("STATIONARY_LAVA")),
 
 	// NETHER
 	PORTAL("nether blocks", XMaterial.NETHER_PORTAL.parseMaterial()),
@@ -29,7 +30,7 @@ public enum GateMaterial {
 	SUGARCANE("sugarcane blocks", XMaterial.SUGAR_CANE.parseMaterial()),
 
 	// WATER
-	WATER("stationary water blocks", XMaterial.supports(13, 0) ? Material.WATER : Material.getMaterial("STATIONARY_WATER")),
+	WATER("stationary water blocks", XReflection.supports(13) ? Material.WATER : Material.getMaterial("STATIONARY_WATER")),
 
 	// WEB
 	WEB("spiders web blocks", XMaterial.COBWEB.parseMaterial());


### PR DESCRIPTION
## Summary
- bump XSeries from 10.0.0 to 13.8.0
- add JitPack so the newer XSeries artifact resolves
- update XMaterial.supports calls for the current two-argument API

## Testing
- docker run --rm -v /Users/rob/Developer/AncientGates:/workspace -w /workspace maven:3.9.11-eclipse-temurin-17 mvn -DskipTests package